### PR TITLE
炎上リスクが高または中のときに表示されるボタンを修正

### DIFF
--- a/src/popup/Popup.jsx
+++ b/src/popup/Popup.jsx
@@ -87,12 +87,20 @@ function Popup() {
             </div>
 
             <div className="actions">
-                { isPostOk ? (
+                {riskLevel === 'high' || riskLevel === 'middle' ? (
+                    <>
+                        <button className='do-post' onClick={handleDoPostButtonClick}>このままポストする</button>
                         <button className="secondary" onClick={handleReturnEnjoButtonClick}>炎上チェックに戻る🔥</button>
-                    ):(
+                    </>
+                ) : riskLevel === 'low' ? (
+                    isPostOk ? (
+                        <button className="secondary" onClick={handleReturnEnjoButtonClick}>炎上チェックに戻る🔥</button>
+                    ) : (
                         <button className='do-post' onClick={handleDoPostButtonClick}>このままポストする</button>
                     )
-                }
+                ) : (
+                    <p>リスクレベルを判定中...</p>
+                )}
             </div>
 
         </div>


### PR DESCRIPTION
## 概要 <!-- 何を実装したか、主な変更点を記述してください -->
炎上リスクが高または中のときに表示されるボタンが、「炎上チェックに戻る🔥」ボタンのみだってのを、「このままポスト」ボタンも表示されるように変更